### PR TITLE
fix: prevent monitoring errors for inactive WireGuard interfaces

### DIFF
--- a/ai_fixes/wg_monitor_missing_interfaces/plan.md
+++ b/ai_fixes/wg_monitor_missing_interfaces/plan.md
@@ -1,0 +1,112 @@
+# 🛠️ Fix Plan: Missing Interfaces Error in wireguard_monitor
+
+## 🧩 Issue Summary
+
+During installation on systems with older WireGuard Gateway versions, the `wireguard_monitor` service throws errors when attempting to check interfaces that no longer exist on the system but remain in the database. These errors appear immediately after the install script completes:
+
+```
+ERROR:app.services.wireguard_monitor:Failed to check interface bs_780379be: Unable to access interface: No such device
+ERROR:app.services.wireguard_monitor:Failed to check interface cer_ae1e05d8: Unable to access interface: No such device
+ERROR:app.services.wireguard_monitor:Failed to check interface KIEL_5ad5c001: Unable to access interface: No such device
+```
+
+## 🔍 Root Cause
+
+The issue occurs because:
+
+1. **Persistent Database**: The SQLite database persists across installations and contains references to WireGuard clients/interfaces from previous installations
+2. **Immediate Monitoring**: During app initialization (`app/__init__.py:88`), the DNS monitoring and auto-reconnect system starts immediately
+3. **Interface Checking**: The monitoring system (`app/services/wireguard_monitor.py:27-39`) calls `wg show <interface>` for each client in the database
+4. **Missing Interfaces**: When interfaces no longer exist on the system, the `wg show` command returns an error that's not gracefully handled during initialization
+
+The error flow:
+1. `app/__init__.py` → `init_dns_monitoring_and_auto_reconnect()` 
+2. → `register_existing_ddns_clients()` → iterates through all clients
+3. → For each client, various services attempt to check the interface status
+4. → `wireguard_monitor.check_interface()` fails with "No such device"
+
+## ✅ Proposed Fix Plan
+
+### 1. **Graceful Error Handling in wireguard_monitor.py**
+   - Modify `check_interface()` method to distinguish between:
+     - Temporary failures (network issues, permission errors)
+     - Permanent failures (interface doesn't exist)
+   - Return a special status for non-existent interfaces instead of logging errors
+
+### 2. **Add Interface Existence Check**
+   - Before calling `wg show`, check if the interface actually exists using:
+     - `ip link show <interface>` command
+     - Or check `/sys/class/net/<interface>` directory existence
+   - This avoids unnecessary error logging for known missing interfaces
+
+### 3. **Database Cleanup Logic**
+   - Add a cleanup method in `ConfigStorageService` to:
+     - Identify clients with non-existent interfaces
+     - Mark them with a special status (e.g., "orphaned" or "missing")
+     - Optionally provide a UI/CLI option to clean up orphaned entries
+
+### 4. **Initialization Optimization**
+   - During app initialization, perform a one-time check for orphaned interfaces
+   - Skip monitoring for clients marked as orphaned
+   - Log informational messages instead of errors for missing interfaces
+
+### 5. **Monitoring Task Enhancement**
+   - Update `app/tasks.py` to handle missing interfaces gracefully
+   - Already partially implemented (lines 59-66) but needs improvement
+   - Ensure consistent behavior between initialization and runtime monitoring
+
+## 🧪 Test Plan
+
+### 1. **Clean Install Test**
+   - Install on a fresh system with no existing database
+   - Verify no errors during initialization
+   - Confirm normal monitoring operation
+
+### 2. **Upgrade Test with Stale Interfaces**
+   - Create a test database with non-existent interface entries
+   - Run installation with `--skip-dependencies --skip-pip`
+   - Verify:
+     - No error logs for missing interfaces
+     - Informational logs about orphaned clients
+     - Clients marked as inactive/orphaned in database
+
+### 3. **Runtime Interface Removal Test**
+   - Start with active WireGuard interfaces
+   - Manually remove an interface using `wg-quick down`
+   - Verify monitoring handles the missing interface gracefully
+
+### 4. **Database Cleanup Test**
+   - Test the cleanup functionality for orphaned entries
+   - Ensure legitimate inactive clients aren't removed
+   - Verify audit trail for removed entries
+
+## 🧯 Rollback Plan
+
+If the fix causes issues:
+
+1. **Revert Code Changes**: Git revert the commit(s) implementing this fix
+2. **Restore Original Behavior**: The original error logging doesn't break functionality, just creates noise
+3. **Database Recovery**: No database schema changes, so no migration rollback needed
+4. **Manual Cleanup**: Provide SQL commands to manually clean orphaned entries if needed
+
+## 📁 Related Files
+
+* `app/services/wireguard_monitor.py` - Primary file needing modification
+* `app/tasks.py` - Monitoring task that calls wireguard_monitor
+* `app/__init__.py` - App initialization that triggers initial checks
+* `app/services/config_storage.py` - May need cleanup methods added
+* `app/services/dns_resolver.py` - DNS monitoring initialization
+* `install.sh` - Installation script (no changes needed)
+
+## 🎯 Implementation Priority
+
+1. **High Priority**: Fix error handling in `wireguard_monitor.py` (prevents log spam)
+2. **Medium Priority**: Add interface existence checks (optimization)
+3. **Low Priority**: Database cleanup functionality (nice-to-have)
+
+## 📊 Success Criteria
+
+- No error logs for missing interfaces during installation
+- Clear informational messages about orphaned clients
+- Existing functionality remains intact
+- Performance impact minimal (<100ms added to initialization)

--- a/ai_fixes/wg_monitor_missing_interfaces/plan.md
+++ b/ai_fixes/wg_monitor_missing_interfaces/plan.md
@@ -2,7 +2,7 @@
 
 ## 🧩 Issue Summary
 
-During installation on systems with older WireGuard Gateway versions, the `wireguard_monitor` service throws errors when attempting to check interfaces that no longer exist on the system but remain in the database. These errors appear immediately after the install script completes:
+During installation, the `wireguard_monitor` service throws errors when attempting to check interfaces that exist in the database but are not yet activated on the system. These errors appear immediately after the install script completes:
 
 ```
 ERROR:app.services.wireguard_monitor:Failed to check interface bs_780379be: Unable to access interface: No such device
@@ -10,103 +10,115 @@ ERROR:app.services.wireguard_monitor:Failed to check interface cer_ae1e05d8: Una
 ERROR:app.services.wireguard_monitor:Failed to check interface KIEL_5ad5c001: Unable to access interface: No such device
 ```
 
+**Key Finding**: These interfaces DO exist in the database and CAN be activated via the UI after installation. The issue is a timing problem where monitoring starts before interfaces are activated.
+
 ## 🔍 Root Cause
 
-The issue occurs because:
+The issue occurs due to a **state/timing mismatch**:
 
-1. **Persistent Database**: The SQLite database persists across installations and contains references to WireGuard clients/interfaces from previous installations
-2. **Immediate Monitoring**: During app initialization (`app/__init__.py:88`), the DNS monitoring and auto-reconnect system starts immediately
-3. **Interface Checking**: The monitoring system (`app/services/wireguard_monitor.py:27-39`) calls `wg show <interface>` for each client in the database
-4. **Missing Interfaces**: When interfaces no longer exist on the system, the `wg show` command returns an error that's not gracefully handled during initialization
+1. **Database State**: The SQLite database contains valid WireGuard client configurations with status information
+2. **System State**: The WireGuard interfaces are not yet active on the system (require manual activation via UI)
+3. **Immediate Monitoring**: During app initialization (`app/__init__.py:88-92`), both DNS monitoring and the monitoring task start immediately
+4. **Interface Checking**: The monitoring system (`app/tasks.py:17-27`) calls `WireGuardMonitor.check_interface()` for ALL clients in the database
+5. **Premature Access**: `wireguard_monitor.check_interface()` runs `wg show <interface>` on interfaces that exist in DB but aren't active yet
 
 The error flow:
-1. `app/__init__.py` → `init_dns_monitoring_and_auto_reconnect()` 
-2. → `register_existing_ddns_clients()` → iterates through all clients
-3. → For each client, various services attempt to check the interface status
-4. → `wireguard_monitor.check_interface()` fails with "No such device"
+1. `app/__init__.py` → `start(app)` → starts monitoring thread
+2. `app/tasks.py:monitor_wireguard()` → `app.config_storage.list_clients()` → gets ALL clients
+3. For each client: `interface_name = os.path.basename(client['config_path'])[0]` → derives interface name from filename
+4. `WireGuardMonitor.check_interface(interface_name)` → `wg show <interface>` → fails with "No such device"
+
+**Critical Insight**: The monitor should respect the client's `status` field in the database and only check interfaces that are marked as 'active'.
 
 ## ✅ Proposed Fix Plan
 
-### 1. **Graceful Error Handling in wireguard_monitor.py**
+### 1. **Respect Database Status in Monitoring (Primary Fix)**
+   - Modify `app/tasks.py:monitor_wireguard()` to only check interfaces for clients with status='active'
+   - Skip monitoring for clients with status='inactive' to avoid premature checks
+   - This prevents checking interfaces that haven't been activated yet
+
+### 2. **Graceful Error Handling in wireguard_monitor.py**
    - Modify `check_interface()` method to distinguish between:
      - Temporary failures (network issues, permission errors)
-     - Permanent failures (interface doesn't exist)
-   - Return a special status for non-existent interfaces instead of logging errors
+     - Interface not active yet (log as info, not error)
+   - Return a status indicating interface availability instead of logging errors
 
-### 2. **Add Interface Existence Check**
-   - Before calling `wg show`, check if the interface actually exists using:
-     - `ip link show <interface>` command
-     - Or check `/sys/class/net/<interface>` directory existence
-   - This avoids unnecessary error logging for known missing interfaces
+### 3. **Status-Aware Monitoring Logic**
+   - Update monitoring task to:
+     - Only monitor clients marked as 'active' in database
+     - Log informational messages for 'inactive' clients that are skipped
+     - Automatically detect when inactive interfaces become active
+   - Ensure status field is properly maintained during activation/deactivation
 
-### 3. **Database Cleanup Logic**
-   - Add a cleanup method in `ConfigStorageService` to:
-     - Identify clients with non-existent interfaces
-     - Mark them with a special status (e.g., "orphaned" or "missing")
-     - Optionally provide a UI/CLI option to clean up orphaned entries
+### 4. **Interface State Detection**
+   - Add a lightweight check to distinguish between:
+     - Interfaces that are defined but not active (normal state)
+     - Interfaces that should be active but failed (error state)
+   - Use this to provide better error messages and status updates
 
-### 4. **Initialization Optimization**
-   - During app initialization, perform a one-time check for orphaned interfaces
-   - Skip monitoring for clients marked as orphaned
-   - Log informational messages instead of errors for missing interfaces
-
-### 5. **Monitoring Task Enhancement**
-   - Update `app/tasks.py` to handle missing interfaces gracefully
-   - Already partially implemented (lines 59-66) but needs improvement
-   - Ensure consistent behavior between initialization and runtime monitoring
+### 5. **Startup Delay Option (Optional)**
+   - Consider adding a small delay before starting monitoring to allow manual interface activation
+   - Or provide a configuration option to disable monitoring during initialization
 
 ## 🧪 Test Plan
 
-### 1. **Clean Install Test**
-   - Install on a fresh system with no existing database
-   - Verify no errors during initialization
-   - Confirm normal monitoring operation
-
-### 2. **Upgrade Test with Stale Interfaces**
-   - Create a test database with non-existent interface entries
-   - Run installation with `--skip-dependencies --skip-pip`
+### 1. **Installation with Existing Database Test**
+   - Run installation on system with existing database containing inactive clients
    - Verify:
-     - No error logs for missing interfaces
-     - Informational logs about orphaned clients
-     - Clients marked as inactive/orphaned in database
+     - No error logs for inactive interfaces during initialization
+     - Informational logs about skipped inactive clients
+     - Monitor only checks active interfaces
 
-### 3. **Runtime Interface Removal Test**
-   - Start with active WireGuard interfaces
-   - Manually remove an interface using `wg-quick down`
-   - Verify monitoring handles the missing interface gracefully
+### 2. **Interface Activation Flow Test**
+   - Start with inactive clients in database
+   - Activate interface via UI
+   - Verify:
+     - Client status changes from 'inactive' to 'active' in database
+     - Monitor automatically starts checking the newly active interface
+     - No errors during the activation process
 
-### 4. **Database Cleanup Test**
-   - Test the cleanup functionality for orphaned entries
-   - Ensure legitimate inactive clients aren't removed
-   - Verify audit trail for removed entries
+### 3. **Mixed State Test**
+   - Have both active and inactive clients in database
+   - Verify:
+     - Only active interfaces are monitored
+     - Inactive interfaces are skipped with info logs
+     - No interference between active and inactive client monitoring
+
+### 4. **Interface Deactivation Test**
+   - Start with active interface
+   - Deactivate via UI or manually with `wg-quick down`
+   - Verify:
+     - Client status changes to 'inactive' in database
+     - Monitor stops checking the deactivated interface
+     - Graceful handling of deactivation during monitoring cycle
 
 ## 🧯 Rollback Plan
 
 If the fix causes issues:
 
 1. **Revert Code Changes**: Git revert the commit(s) implementing this fix
-2. **Restore Original Behavior**: The original error logging doesn't break functionality, just creates noise
-3. **Database Recovery**: No database schema changes, so no migration rollback needed
-4. **Manual Cleanup**: Provide SQL commands to manually clean orphaned entries if needed
+2. **Restore Original Behavior**: The original monitoring behavior (checking all clients) will resume
+3. **No Data Loss**: No database schema changes, all client data remains intact
+4. **Temporary Workaround**: If needed, manually activate interfaces before service startup to avoid errors
 
 ## 📁 Related Files
 
-* `app/services/wireguard_monitor.py` - Primary file needing modification
-* `app/tasks.py` - Monitoring task that calls wireguard_monitor
-* `app/__init__.py` - App initialization that triggers initial checks
-* `app/services/config_storage.py` - May need cleanup methods added
-* `app/services/dns_resolver.py` - DNS monitoring initialization
-* `install.sh` - Installation script (no changes needed)
+* `app/tasks.py` - **Primary file**: Monitoring task that needs status-aware filtering
+* `app/services/wireguard_monitor.py` - Error handling improvements
+* `app/services/config_storage.py` - Database client listing (list_clients method)
+* `app/__init__.py` - App initialization that starts monitoring (no changes needed)
+* `app/services/wireguard.py` - Interface activation logic (reference only)
 
 ## 🎯 Implementation Priority
 
-1. **High Priority**: Fix error handling in `wireguard_monitor.py` (prevents log spam)
-2. **Medium Priority**: Add interface existence checks (optimization)
-3. **Low Priority**: Database cleanup functionality (nice-to-have)
+1. **High Priority**: Status-aware monitoring in `app/tasks.py` (prevents checking inactive interfaces)
+2. **Medium Priority**: Better error handling in `wireguard_monitor.py` (cleaner logs)
+3. **Low Priority**: Startup delay configuration option (edge case optimization)
 
 ## 📊 Success Criteria
 
-- No error logs for missing interfaces during installation
-- Clear informational messages about orphaned clients
+- No error logs for inactive interfaces during installation
+- Monitor only checks interfaces with status='active' in database  
+- Clear informational logs about skipped inactive clients
 - Existing functionality remains intact
-- Performance impact minimal (<100ms added to initialization)
+- Interfaces can still be activated/deactivated via UI without issues

--- a/app/services/wireguard_monitor.py
+++ b/app/services/wireguard_monitor.py
@@ -35,7 +35,11 @@ class WireGuardMonitor:
             )
             
             if result.returncode != 0:
-                logger.error(f"Failed to check interface {interface}: {result.stderr}")
+                # Check if interface doesn't exist (common for inactive interfaces)
+                if "No such device" in result.stderr:
+                    logger.debug(f"Interface {interface} not found (inactive): {result.stderr}")
+                else:
+                    logger.error(f"Failed to check interface {interface}: {result.stderr}")
                 return {}
             
             # Parse output

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -19,6 +19,11 @@ def monitor_wireguard(app):
                 # Update status for each client
                 for client in clients:
                     try:
+                        # Only monitor clients that are marked as active in the database
+                        if client.get('status') != 'active':
+                            logger.debug(f"Skipping monitoring for inactive client {client.get('name', 'Unknown')} (status: {client.get('status', 'unknown')})")
+                            continue
+                        
                         # Get interface name from config path
                         import os
                         interface_name = os.path.splitext(os.path.basename(client['config_path']))[0]


### PR DESCRIPTION
 Description:
  ## Summary
  - Fix monitoring errors for inactive WireGuard interfaces during startup
  - Skip monitoring clients with status != 'active' to avoid "No such device" errors
  - Improve error handling to distinguish between missing interfaces and actual failures

  ## Root Cause
  The monitor was checking ALL clients in database during startup, including inactive ones that haven't been activated via UI yet. This caused false error logs when running `wg show`
  on non-existent interfaces.

  ## Changes Made
  - **app/tasks.py**: Only monitor clients with status='active' in database
  - **app/services/wireguard_monitor.py**: Log missing interfaces as debug instead of error

  ## Test Plan
  - [x] Installation with existing inactive clients shows no errors
  - [x] Active interfaces continue to be monitored normally
  - [x] Inactive clients are skipped with debug logs